### PR TITLE
fix hover popup-filter, remove redundant code

### DIFF
--- a/autoload/lsp/hover.vim
+++ b/autoload/lsp/hover.vim
@@ -90,11 +90,6 @@ def HoverWinFilterKey(hoverWin: number, key: string): bool
     keyHandled = true
   endif
 
-  if !keyHandled
-    # For any other key, close the hover window
-    hoverWin->popup_close()
-  endif
-
   return keyHandled
 enddef
 


### PR DESCRIPTION
The original few lines of code are redundant.
Just return false and let vim handle the other keys. The redundant code disabled mouse scrolling, and the popup will be closed automatically after some seconds (I don't know why it is closed automatically)